### PR TITLE
Fix profile.d script after #1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,13 +20,13 @@ unset GIT_DIR
 write_profile() {
   local root_dir="$1"
   # This assumes that Heroku initially looks for profiles at the $HOME folder, which it does
-  # The $HOME variable must be escaped, so that its value is resolved at runtime and not now.
-  local subdir="\$HOME/$2"
+  local subdir="$2"
   mkdir -p $root_dir/.profile.d
 
   # Set the home directory to be the subdir and source all profiles that
   # were placed here by the invoked buildpack
-  echo "export HOME=$subdir && source $subdir/.profile.d/*" > $root_dir/.profile.d/heroku-subdir-init.sh
+  # The $HOME variable must be escaped, so that its value is resolved at runtime and not now.
+  echo "export HOME=\"\$HOME/$subdir\" && source \"$subdir/.profile.d/\"*" > "$root_dir/.profile.d/heroku-subdir-init.sh"
 }
 
 


### PR DESCRIPTION
Follow-up to #1.

Prior to this fix, the profile.d script content would be of form:

```
export HOME=$HOME/server && source $HOME/server/.profile.d/*
```

Bash resolves the value for `$HOME` prior to interpolating the
`source` command, so the end result was equivalent to:

```
export HOME=/app/server && source /app/server/server/.profile.d/*
```

(Note the double `/server` in the path.)

Now the profile.d script content is of form:

```
export HOME=$HOME/server && source $HOME/.profile.d/*
```

Which now resolves to the correct:

```
export HOME=/app/server && source /app/server/.profile.d/*
```