### PR TITLE
Add deprecation notice to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,6 @@
+# STATUS: DEPRECATED AND UNMAINTAINED
+This package is deprecated. Please use https://github.com/timanovsky/subdir-heroku-buildpack or https://github.com/lstoll/heroku-buildpack-monorepo.
+
 # Heroku Buildpack Select Subdir
 
 Allows you to have a monolithic repo with multiple Heroku apps in different subdirectories (like Google!).


### PR DESCRIPTION
Per discussion on #1 

@jaredp I think this is the buildpack we're going to cutover to. I already tested it in one environment and it went smoothly. I'm not sure it's the canonical solution (not even sure there is one) but it seems to be fairly popular and is an easy swap for this buildpack.